### PR TITLE
decode response strings as UTF-8.

### DIFF
--- a/moomin.el
+++ b/moomin.el
@@ -165,6 +165,10 @@
   (transient-mark-mode 1)
   (deactivate-mark t))
 
+(defun moomin-buffer-parser ()
+  (decode-coding-string (buffer-string) 'utf-8)
+  )
+
 (defun moomin-login ()
   (request
    moomin-wiki-url-base
@@ -175,7 +179,7 @@
                                          (login . "Login")
                                          (login . "Login")))
    :headers (moomin-request-headers)
-   :parser 'buffer-string
+   :parser 'moomin-buffer-parser
    :sync t))
 
 (defun moomin-get-current-revision (page)
@@ -186,7 +190,7 @@
      :params '((action . "edit")
                (editor . "text"))
      :headers (moomin-request-headers)
-     :parser 'buffer-string
+     :parser 'moomin-buffer-parser
      :sync t
      :success (function*
                (lambda (&key data &allow-other-keys)
@@ -243,7 +247,7 @@
    :params '((action . "edit")
              (editor . "text"))
    :headers (moomin-request-headers)
-   :parser 'buffer-string
+   :parser 'moomin-buffer-parser
    :sync t
    :success (function*
              (lambda (&key data &allow-other-keys)
@@ -268,7 +272,7 @@
                      (comment . "")
                      (category . "")))
             :headers (moomin-request-headers)
-            :parser 'buffer-string
+            :parser 'moomin-buffer-parser
             :sync t
             :success (function*
                       (lambda (&key data &allow-other-keys)
@@ -303,7 +307,7 @@
    (concat moomin-wiki-url-base "?action=titleindex")
    :type "GET"
    :headers (moomin-request-headers)
-   :parser 'buffer-string
+   :parser 'moomin-buffer-parser
    :sync t
    :success (function*
              (lambda (&key data &allow-other-keys)


### PR DESCRIPTION
In my environment, to avoid garbled characters, I have to make request's parser function decoding character code.
(I assume utf-8 in this PR, but this may vary...)